### PR TITLE
Ensure token persists when form validation errors are raised

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,12 @@ class UsersController < ApplicationController
       redirect_to @user
     else
       flash[:errors] = @user.errors.full_messages
-      redirect_to signup_path
+
+      if params[:user][:token]
+        redirect_to signup_path(token: params[:user][:token])
+      else
+        redirect_to signup_path
+      end
     end
   end
 


### PR DESCRIPTION
Before when validation failed for any reason, the signup form would reload without the signup token.

Now that no longer happens as the redirect includes the sign up token if it exists.

**Test Plan**
- On master branch, signup with a token and purposely fail a validation (mismatched password for example) and watch as the form reloads without a signup token.
- Then go to this branch and do the same thing and ensure the token persists.